### PR TITLE
re mods to deal with changed URL_MAIN contents

### DIFF
--- a/src/download.rs
+++ b/src/download.rs
@@ -134,7 +134,7 @@ impl Downloader {
             .context("fetching main releases URL")?;
         let text = res.text().await?;
 
-        let re = Regex::new(r#"<a href="/release/(?P<entity>[^"]+)">(?P<version>[^<]+)</a>"#)?;
+        let re = Regex::new(r#"<a href="(?:/release/)?(?P<entity>[^"]+)">(?P<version>[^<]+)</a>"#)?;
 
         let mut records = vec![];
 


### PR DESCRIPTION
Was not working, due to the `href=` no longer having the "/release/" component prefix.